### PR TITLE
Book: small correction to hysteresis

### DIFF
--- a/src/book.md
+++ b/src/book.md
@@ -3336,8 +3336,8 @@ The hysteresis levels are controlled by the [hysteresis parameters](/part3/confi
 
 These are applied at the end of each epoch during [effective balance updates](/part3/transition/epoch/#effective-balances-updates). Every validator in the state (whether active or not) has its effective balance updated as follows:
 
-  - If actual balance is less than effective balance minus 0.25 (`=` `HYSTERESIS_DOWNWARD_MULTIPLIER` `/` `HYSTERESIS_QUOTIENT`) increments (ETH), then reduce the effective balance by an increment.
-  - If actual balance is more than effective balance plus 1.25 (`=` `HYSTERESIS_UPWARD_MULTIPLIER` `/` `HYSTERESIS_QUOTIENT`) increments (ETH), then increase the effective balance by an increment.
+  - If actual balance is less than effective balance minus 0.25 (`=` `HYSTERESIS_DOWNWARD_MULTIPLIER` `/` `HYSTERESIS_QUOTIENT`) increments (ETH), then reduce the effective balance by a whole number of increments.
+  - If actual balance is more than effective balance plus 1.25 (`=` `HYSTERESIS_UPWARD_MULTIPLIER` `/` `HYSTERESIS_QUOTIENT`) increments (ETH), then increase the effective balance by a whole number of increments.
 
 The effect of the hysteresis is that the effective balance cannot change more often than it takes for a validator's actual balance to change by 0.5&nbsp;ETH, which would normally take several weeks or months.
 


### PR DESCRIPTION
A bit of a nit.

The current wording is actually incorrect, and we can see as much by following the [preceding link](https://eth2book.info/capella/part3/transition/epoch/#effective-balances-updates) to look at the actual algorithm.

This difference will be more meaningful when epbs means validator balances change faster, or when considering top-up deposits which increase effective balance to `balance - balance % 1 eth` directly, instead of incrementally/iteratively.